### PR TITLE
feat(root): switches to SSG

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -42,3 +42,4 @@ postcss.config.cjs
 tailwind.config.ts
 *.md
 *.mdx
+_routes.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # [codybrunner.com](https://codybrunner.com)
+
+## Static Site Generator (Node.js)
+
+```
+pnpm build.server
+```

--- a/adapters/static/vite.config.ts
+++ b/adapters/static/vite.config.ts
@@ -1,0 +1,19 @@
+import { staticAdapter } from '@builder.io/qwik-city/adapters/static/vite';
+import { extendConfig } from '@builder.io/qwik-city/vite';
+import baseConfig from '../../vite.config';
+
+export default extendConfig(baseConfig, () => {
+  return {
+    build: {
+      ssr: true,
+      rollupOptions: {
+        input: ['@qwik-city-plan'],
+      },
+    },
+    plugins: [
+      staticAdapter({
+        origin: 'https://codybrunner.com',
+      }),
+    ],
+  };
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"build": "qwik build",
 		"build.client": "vite build",
 		"build.preview": "vite build --ssr src/entry.preview.tsx",
-		"build.server": "vite build -c adapters/cloudflare-pages/vite.config.ts",
+		"build.server": "vite build -c adapters/static/vite.config.ts",
 		"build.types": "tsc --incremental --noEmit",
 		"deploy": "wrangler pages publish ./dist",
 		"dev": "vite --mode ssr",
@@ -26,7 +26,7 @@
 		"fmt.check": "prettier --check .",
 		"lint": "eslint \"src/**/*.ts*\"",
 		"preview": "qwik build preview && vite preview --open",
-		"serve": "wrangler pages dev ./dist",
+		"preview:wrangler": "wrangler pages dev ./dist",
 		"start": "vite --open --mode ssr",
 		"qwik": "qwik"
 	},


### PR DESCRIPTION
## What does this PR do?

- moves from `cloudflare-pages` to `static` site adapter for deployments.
- all pages are now rendered via SSG instead of SSR