### PR TITLE
chore(routes): adds back twitter:domain

### DIFF
--- a/src/routes/404.tsx
+++ b/src/routes/404.tsx
@@ -26,12 +26,80 @@ export const head: DocumentHead = {
 	title: NOT_FOUND.title,
 	meta: [
 		{
-			name: 'og:description',
+			name: 'description',
 			content: NOT_FOUND.description,
 		},
 		{
-			name: 'og:title',
+			property: 'og:description',
+			content: NOT_FOUND.description,
+		},
+		{
+			property: 'og:image',
+			content: `/images/page-not-found.svg`,
+		},
+		{
+			property: 'og:image:alt',
+			content: `Logo for ${NOT_FOUND.title}`,
+		},
+		{
+			property: 'og:image:height',
+			content: `512`,
+		},
+		{
+			property: 'og:image:width',
+			content: `512`,
+		},
+		{
+			property: 'og:locale',
+			content: 'en_US',
+		},
+		{
+			property: 'og:title',
 			content: `${NOT_FOUND.title} | ${SITE.title}`,
+		},
+		{
+			property: 'og:type',
+			content: 'website',
+		},
+		{
+			property: 'og:url',
+			content: SITE.origin,
+		},
+		{
+			name: 'twitter:card',
+			content: 'summary_large_image',
+		},
+		{
+			name: 'twitter:creator',
+			content: SITE.twitter,
+		},
+		{
+			name: 'twitter:description',
+			content: NOT_FOUND.description,
+		},
+		{
+			name: 'twitter:domain',
+			content: SITE.origin.replace('https://', ''),
+		},
+		{
+			property: 'twitter:image',
+			content: `/images/page-not-found.svg`,
+		},
+		{
+			property: 'twitter:image:alt',
+			content: `Logo for ${NOT_FOUND.title}`,
+		},
+		{
+			name: 'twitter:site',
+			content: SITE.twitter,
+		},
+		{
+			name: 'twitter:title',
+			content: `${NOT_FOUND.title} | ${SITE.title}`,
+		},
+		{
+			name: 'twitter:url',
+			content: SITE.origin,
 		},
 	],
 }

--- a/src/routes/about/index.tsx
+++ b/src/routes/about/index.tsx
@@ -200,6 +200,10 @@ export const head: DocumentHead = {
 			content: ABOUT.description,
 		},
 		{
+			name: 'twitter:domain',
+			content: SITE.origin.replace('https://', ''),
+		},
+		{
 			property: 'twitter:image',
 			content: `/android-chrome-512x512.png`,
 		},

--- a/src/routes/bookshelf/index.tsx
+++ b/src/routes/bookshelf/index.tsx
@@ -219,6 +219,10 @@ export const head: DocumentHead = {
 			content: BOOKSHELF.description,
 		},
 		{
+			name: 'twitter:domain',
+			content: SITE.origin.replace('https://', ''),
+		},
+		{
 			property: 'twitter:image',
 			content: `/android-chrome-512x512.png`,
 		},

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -160,7 +160,6 @@ export const head: DocumentHead = {
 			property: 'og:locale',
 			content: 'en_US',
 		},
-
 		{
 			property: 'og:title',
 			content: `Home | ${SITE.title}`,
@@ -184,6 +183,10 @@ export const head: DocumentHead = {
 		{
 			name: 'twitter:description',
 			content: SITE.description,
+		},
+		{
+			name: 'twitter:domain',
+			content: SITE.origin.replace('https://', ''),
 		},
 		{
 			property: 'twitter:image',

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -105,6 +105,10 @@ export const head: DocumentHead = {
 			content: PROJECTS.description,
 		},
 		{
+			name: 'twitter:domain',
+			content: SITE.origin.replace('https://', ''),
+		},
+		{
 			property: 'twitter:image',
 			content: `/android-chrome-512x512.png`,
 		},

--- a/src/routes/uses/index.tsx
+++ b/src/routes/uses/index.tsx
@@ -125,6 +125,10 @@ export const head: DocumentHead = {
 			content: USES.description,
 		},
 		{
+			name: 'twitter:domain',
+			content: SITE.origin.replace('https://', ''),
+		},
+		{
 			property: 'twitter:image',
 			content: `/android-chrome-512x512.png`,
 		},


### PR DESCRIPTION
## What does this PR do?

- adds back `twitter:domain`
- updates meta tags on 404